### PR TITLE
Output "title" entities' contents as CDATA

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ async function handleRequest(request) {
 
         contents.forEach(element => {
             files.push({
-                "title": encodeURIComponent(element['Key'][0]),
+                "title": "![CDATA[" + element['Key'][0] + "]]",
                 "pubDate": element['LastModified'][0],
                 "size": element['Size'][0],
                 "url": `${PUBLIC_URL}${encodeURIComponent(element['Key'][0])}`


### PR DESCRIPTION
Instead of encoding the file name as an URI, wrap the contents of the "title" entities into a CDATA section.